### PR TITLE
Set Host property on a proxy request

### DIFF
--- a/src/toolkit/proxy.go
+++ b/src/toolkit/proxy.go
@@ -42,6 +42,7 @@ func ProxyHandler(targetURL *url.URL, ec *EventsContainer) http.Handler {
 	director := func(req *http.Request) {
 		req.URL.Scheme = targetURL.Scheme
 		req.URL.Host = targetURL.Host
+		req.Host = targetURL.Host
 		req.URL.Path = singleJoiningSlash(targetURL.Path, req.URL.Path)
 		if targetQuery == "" || req.URL.RawQuery == "" {
 			req.URL.RawQuery = targetQuery + req.URL.RawQuery


### PR DESCRIPTION
When sending a request from the reverse proxy we should also set a Host
property on a request object. It will in turn set the Host header, which
might be required by some of the servers as thye rely on the Host header
rather than on a URL.